### PR TITLE
Configure Dependabot to only provide security updates for Go packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       "Go modules updates":
+        applies-to: "security-updates"
         dependency-type: "production"


### PR DESCRIPTION
This PR modifies the Dependabot configuration to only provide security updates for Go packages, eliminating regular version updates that can be noisy. It does this by adding the 'applies-to: security-updates' parameter to the Go modules group configuration.