### PR TITLE
fix: bump Go version in Dockerfile from 1.21 to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as build
+FROM golang:1.24-alpine AS build
 
 ARG GIT_BRANCH
 ARG GITHUB_SHA


### PR DESCRIPTION
go.mod requires go >= 1.24.0 but the Dockerfile used golang:1.21-alpine, causing all master builds to fail since Feb 3. Also fixed `as` → `AS` casing to suppress the Docker build warning.