### PR TITLE
Add shell completions for bash, zsh, and fish

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - completions/*
     rlcp: true
 
 
@@ -60,6 +61,10 @@ brews:
     homepage: "https://proxy-cron.umputun.dev/"
     description: "proxy-cron is a simple HTTP proxy server designed to handle requests based on crontab-like scheduling."
     license: "MIT"
+    extra_install: |
+      bash_completion.install "completions/proxy-cron.bash" => "proxy-cron"
+      zsh_completion.install "completions/proxy-cron.zsh" => "_proxy_cron"
+      fish_completion.install "completions/proxy-cron.fish" => "proxy-cron.fish"
 
 nfpms:
   - id: proxy-cron
@@ -77,3 +82,10 @@ nfpms:
     bindir: /usr/bin
     epoch: 1
     release: 1
+    contents:
+      - src: completions/proxy-cron.bash
+        dst: /usr/share/bash-completion/completions/proxy-cron
+      - src: completions/proxy-cron.zsh
+        dst: /usr/share/zsh/vendor-completions/_proxy_cron
+      - src: completions/proxy-cron.fish
+        dst: /usr/share/fish/vendor_completions.d/proxy-cron.fish

--- a/app/main.go
+++ b/app/main.go
@@ -41,7 +41,9 @@ type options struct {
 var revision = "unknown"
 
 func main() {
-	fmt.Printf("proxy-cron %s\n", revision)
+	if os.Getenv("GO_FLAGS_COMPLETION") == "" {
+		fmt.Printf("proxy-cron %s\n", revision)
+	}
 	opts := options{}
 	p := flags.NewParser(&opts, flags.PrintErrors|flags.PassDoubleDash|flags.HelpFlag)
 	p.SubcommandsOptional = true

--- a/completions/proxy-cron.bash
+++ b/completions/proxy-cron.bash
@@ -1,0 +1,8 @@
+# bash completion for proxy-cron (generated via go-flags)
+_proxy_cron() {
+    local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    local IFS=$'\n'
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null))
+    return 0
+}
+complete -o default -F _proxy_cron proxy-cron

--- a/completions/proxy-cron.bash
+++ b/completions/proxy-cron.bash
@@ -1,8 +1,7 @@
 # bash completion for proxy-cron (generated via go-flags)
 _proxy_cron() {
     local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
-    local IFS=$'\n'
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null))
+    mapfile -t COMPREPLY < <(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null)
     return 0
 }
 complete -o default -F _proxy_cron proxy-cron

--- a/completions/proxy-cron.fish
+++ b/completions/proxy-cron.fish
@@ -1,0 +1,2 @@
+# fish completion for proxy-cron (generated via go-flags)
+complete -c proxy-cron -a '(GO_FLAGS_COMPLETION=1 proxy-cron (commandline -cop) 2>/dev/null)'

--- a/completions/proxy-cron.fish
+++ b/completions/proxy-cron.fish
@@ -1,2 +1,2 @@
 # fish completion for proxy-cron (generated via go-flags)
-complete -c proxy-cron -a '(GO_FLAGS_COMPLETION=1 proxy-cron (commandline -cop) 2>/dev/null)'
+complete -c proxy-cron -a '(GO_FLAGS_COMPLETION=verbose proxy-cron (commandline -cop) 2>/dev/null | string replace -r "\\s+# " "\t")'

--- a/completions/proxy-cron.zsh
+++ b/completions/proxy-cron.zsh
@@ -1,0 +1,15 @@
+#compdef proxy-cron
+
+# zsh completion for proxy-cron (generated via go-flags)
+_proxy_cron() {
+    local IFS=$'\n'
+    local -a completions
+    completions=($(GO_FLAGS_COMPLETION=1 "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null))
+    if (( ${#completions} )); then
+        compadd -- "${completions[@]}"
+    else
+        _files
+    fi
+}
+
+_proxy_cron "$@"

--- a/completions/proxy-cron.zsh
+++ b/completions/proxy-cron.zsh
@@ -2,11 +2,24 @@
 
 # zsh completion for proxy-cron (generated via go-flags)
 _proxy_cron() {
-    local IFS=$'\n'
-    local -a completions
-    completions=($(GO_FLAGS_COMPLETION=1 "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null))
-    if (( ${#completions} )); then
-        compadd -- "${completions[@]}"
+    local -a lines
+    lines=(${(f)"$(GO_FLAGS_COMPLETION=verbose "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null)"})
+    if (( ${#lines} )); then
+        local -a descr
+        local line item desc
+        for line in "${lines[@]}"; do
+            if [[ "$line" = *'  # '* ]]; then
+                item="${line%%  *}"
+                desc="${line#*  \# }"
+                descr+=("${item//:/\\:}:${desc}")
+            else
+                item="${line%%  *}"
+                [[ -z "$item" ]] && item="$line"
+                [[ "$item" = *" "* ]] && continue
+                descr+=("${item//:/\\:}")
+            fi
+        done
+        _describe 'command' descr
     else
         _files
     fi


### PR DESCRIPTION
## Summary

- Add completion wrapper scripts for bash, zsh, and fish that use go-flags' built-in `GO_FLAGS_COMPLETION` mechanism
- Update `.goreleaser.yml` to include completions in release archives, Homebrew formula (`extra_install`), and deb/rpm packages (`contents`)
- Suppress version banner when running in completion mode to avoid polluting output

After this, `brew install umputun/apps/proxy-cron` will automatically install shell completions.